### PR TITLE
[IMP] add simulcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ The available environment variables are:
 - **RTC_MAX_PORT**: Upper bound for the range of ports used by the RTC server, must be open in both TCP and UDP
 - **MAX_BUF_IN**: if set, limits the incoming buffer size per session (user)
 - **MAX_BUF_OUT**: if set, limits the outgoing buffer size per session (user)
-- **MAX_BITRATE_IN**: if set, limits the incoming bitrate per session (user)
-- **MAX_BITRATE_OUT**: if set, limits the outgoing bitrate per session (user)
+- **MAX_BITRATE_IN**: if set, limits the incoming bitrate per session (user), defaults to 8mbps
+- **MAX_BITRATE_OUT**: if set, limits the outgoing bitrate per session (user), defaults to 10mbps
+- **MAX_VIDEO_BITRATE**: if set, defines the `maxBitrate` of the highest encoding layer (simulcast), defaults to 4mbps
 - **CHANNEL_SIZE**: the maximum amount of users per channel, defaults to 100
 - **WORKER_LOG_LEVEL**: "none" | "error" | "warn" | "debug", will only work if `DEBUG` is properly set.
 - **LOG_LEVEL**: "none" | "error" | "warn" | "info" | "debug" | "verbose"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "odoo-sfu",
   "description": "Odoo's SFU server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Odoo",
   "license": "LGPL-3.0",
   "type": "module",

--- a/src/models/session.js
+++ b/src/models/session.js
@@ -315,6 +315,7 @@ export class Session extends EventEmitter {
                             dtlsParameters: this._ctsTransport.dtlsParameters,
                             sctpParameters: this._ctsTransport.sctpParameters,
                         },
+                        producerOptionsByKind: config.rtc.producerOptionsByKind,
                     },
                 });
                 await Promise.all([


### PR DESCRIPTION
This commit adds the support for simulcast:

Simulcast is a way to let producers sent multiple version of the streams
as different layers of quality. This allows the server to select
the optimal layer based on the available bandwidth for each client.

Two env variables are used to control this feature:

`VIDEO_MAX_BITRATE`: Specifies the bitrate for the highest encoding
layer per stream. It sets the `maxBitrate` property of the
highest encoding of the `RTCRtpEncodingParameters` and is used
to compute the bitrate attributed to the other layers.

`MAX_BITRATE_OUT`: The maximum outgoing bitrate (=from the server) per
session (meaning that this cap is shared between all the incoming
streams for any given user). The appropriate simulcast layers used by
each consumer will be selected to honor this limit. If the bitrate is
still too high, packets will be dropped. Without this limit, the
connections will use as much bandwidth as possible, which means that
the simulcast layer will be chosen based on the client (or server) max
available bandwidth.

This commits also bumps the minor version as the bundle and the server
need to be updated to benefit from the feature (although both the
client and the server are backwards compatible).