### PR TITLE
[IMP] Add per-channel encryption feature

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -158,13 +158,15 @@ export class SfuClient extends EventTarget {
      * @param {string} url
      * @param {string} jsonWebToken
      * @param {Object} [options]
+     * @param {string} [options.channelUUID]
      * @param {[]} [options.iceServers]
      */
-    async connect(url, jsonWebToken, { iceServers } = {}) {
+    async connect(url, jsonWebToken, { channelUUID, iceServers } = {}) {
         // saving the options for so that the parameters are saved for reconnection attempts
         this._url = url.replace(/^http/, "ws"); // makes sure the url is a websocket url
         this._jsonWebToken = jsonWebToken;
         this._iceServers = iceServers;
+        this._channelUUID = channelUUID;
         this._connectRetryDelay = INITIAL_RECONNECT_DELAY;
         this._device = this._createDevice();
         await this._connect();
@@ -393,7 +395,9 @@ export class SfuClient extends EventTarget {
             webSocket.addEventListener(
                 "open",
                 () => {
-                    webSocket.send(JSON.stringify(this._jsonWebToken));
+                    webSocket.send(
+                        JSON.stringify({ channelUUID: this._channelUUID, jwt: this._jsonWebToken })
+                    );
                 },
                 { once: true }
             );

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -22,12 +22,13 @@ export function close() {
 
 /**
  * @param {string} jsonWebToken
+ * @param {WithImplicitCoercion<string>} [key] buffer/b64 str
  * @returns {Promise<any>} json serialized data
  * @throws {AuthenticationError}
  */
-export async function verify(jsonWebToken) {
+export async function verify(jsonWebToken, key = jwtKey) {
     try {
-        return jwt.verify(jsonWebToken, jwtKey, {
+        return jwt.verify(jsonWebToken, key, {
             algorithms: ["HS256"],
         });
     } catch {

--- a/src/services/http.js
+++ b/src/services/http.js
@@ -52,7 +52,7 @@ export async function start({ httpInterface = config.HTTP_INTERFACE, port = conf
         callback: async (req, res, { host, protocol, remoteAddress, searchParams }) => {
             try {
                 const jsonWebToken = req.headers.authorization?.split(" ")[1];
-                /** @type {{ iss: string }} */
+                /** @type {{ iss: string, key: string || undefined }} */
                 const claims = await auth.verify(jsonWebToken);
                 if (!claims.iss) {
                     logger.warn(`${remoteAddress}: missing issuer claim when creating channel`);
@@ -60,6 +60,7 @@ export async function start({ httpInterface = config.HTTP_INTERFACE, port = conf
                     return res.end();
                 }
                 const channel = await Channel.create(remoteAddress, claims.iss, {
+                    key: claims.key,
                     useWebRtc: searchParams.get("webRTC") !== "false",
                 });
                 res.setHeader("Content-Type", "application/json");

--- a/tests/utils/network.js
+++ b/tests/utils/network.js
@@ -51,6 +51,7 @@ export class LocalNetwork {
     async getChannelUUID(useWebRtc = true) {
         const jwt = this.makeJwt({
             iss: `http://${this.hostname}:${this.port}/`,
+            key: HMAC_B64_KEY,
         });
         const response = await fetch(
             `http://${this.hostname}:${this.port}/v${http.API_VERSION}/channel?webRTC=${useWebRtc}`,
@@ -59,7 +60,7 @@ export class LocalNetwork {
                 headers: {
                     Authorization: "jwt " + jwt,
                 },
-            },
+            }
         );
         const result = await response.json();
         return result.uuid;
@@ -104,6 +105,7 @@ export class LocalNetwork {
                 sfu_channel_uuid: channelUUID,
                 session_id: sessionId,
             }),
+            { channelUUID }
         );
         const channel = Channel.records.get(channelUUID);
         await isClientAuthenticated;


### PR DESCRIPTION
This commit adds per-channel encryption to prevent users from signing JWTs for channels that they did not create.

This change is useful for cases like Odoo.SH where multiple parties can use the same SFU with the same credentials.

task-3861455