### PR TITLE
[FIX] set a default behavior for http methods

### DIFF
--- a/src/services/http.js
+++ b/src/services/http.js
@@ -181,6 +181,10 @@ class RouteListener {
             case "POST":
                 registeredRoutes = this.POSTs.entries();
                 break;
+            default:
+                logger.warn(`[${remoteAddress}] ${req.method} is not allowed on ${req.url}`);
+                res.statusCode = 405; // Method not allowed
+                return res.end();
         }
         for (const [pattern, options] of registeredRoutes) {
             if (pathname === pattern) {


### PR DESCRIPTION
Before this commit. there was no default behavior in case the method request was not handled, which meant that we would try to iterate on an undefined `registeredRoutes` which would lead to a traceback.

The issue is not critical as it only leads to an `ERROR` in the logs.