### PR TITLE
[FIX] prevent outdated info feedback

### DIFF
--- a/src/models/channel.ts
+++ b/src/models/channel.ts
@@ -10,7 +10,6 @@ import {
     Session,
     SESSION_CLOSE_CODE,
     type SessionId,
-    type SessionInfo
 } from "#src/models/session.ts";
 import { getWorker, type RtcWorker } from "#src/services/rtc.ts";
 
@@ -201,14 +200,6 @@ export class Channel extends EventEmitter {
             sessionsStats: await this.getSessionsStats(),
             webRtcEnabled: Boolean(this._worker)
         };
-    }
-
-    get sessionsInfo(): Record<SessionId, SessionInfo> {
-        const sessionsInfo: Record<SessionId, SessionInfo> = {};
-        for (const session of this.sessions.values()) {
-            sessionsInfo[session.id] = session.info;
-        }
-        return sessionsInfo;
     }
 
     get webRtcServer(): WebRtcServer | undefined {

--- a/src/models/session.ts
+++ b/src/models/session.ts
@@ -573,11 +573,19 @@ export class Session extends EventEmitter {
                         this.info[key as keyof SessionInfo] = Boolean(value);
                     }
                 }
-                if (needRefresh) {
+                const sessions = this._channel.sessions;
+                if (needRefresh && sessions.size > 1) {
+                    const payload: Record<SessionId, SessionInfo> = {};
+                    for (const session of this._channel.sessions.values()) {
+                        if (session.id === this.id) {
+                            continue;
+                        }
+                        payload[session.id] = session.info;
+                    }
                     this.bus!.send(
                         {
                             name: SERVER_MESSAGE.INFO_CHANGE,
-                            payload: this._channel.sessionsInfo
+                            payload,
                         },
                         { batch: true }
                     );

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -117,12 +117,17 @@ describe("Full network", () => {
             isTalking: false,
             isSelfMuted: true
         };
-        user3.sfuClient.updateInfo(user3Info, { needRefresh: true });
-        const [event] = await once(user3.sfuClient, "update");
+        user3.sfuClient.updateInfo(user3Info);
+        const [event] = await once(user2.sfuClient, "update");
         expect(event.detail.payload).toEqual({
+            [user3.session.id]: user3Info,
+        });
+        // with needRefresh, the client should receive the info of all sessions except that of their own
+        user2.sfuClient.updateInfo({ isTalking: true }, { needRefresh: true });
+        const [event2] = await once(user2.sfuClient, "update");
+        expect(event2.detail.payload).toEqual({
             [user1.session.id]: {},
-            [user2.session.id]: {},
-            [user3.session.id]: user3Info
+            [user3.session.id]: user3Info,
         });
     });
     test("Connecting multiple times with the same session id closes the previous ones", async () => {


### PR DESCRIPTION
When a client was sending their info to the server with a `needRefresh=true`, the server would send their own info back, which could be outdated.